### PR TITLE
Multiple palettes in `split_by`

### DIFF
--- a/R/boxviolinplot.R
+++ b/R/boxviolinplot.R
@@ -523,9 +523,16 @@ BoxViolinPlot <- function(
         datas <- split(data, data[[split_by]])
         # keep the order of levels
         datas <- datas[levels(data[[split_by]])]
+        if (length(palette) > 1) {
+        	if (length(palette)!=length(datas)) {stop("split_by and palette length mismatches.")}
+        } else {
+        	palette <- rep(palette, length(datas))
+        }
+    	names(palette) <- names(datas)
     } else {
         datas <- list(data)
         names(datas) <- "..."
+        names(palette) <- "..."
     }
 
     stat_name <- stat_name %||% paste0(y, " (", deparse(substitute(add_stat)), ")")
@@ -542,7 +549,7 @@ BoxViolinPlot <- function(
                 x = x, x_sep = x_sep, y = y, base = base, in_form = in_form,
                 sort_x = sort_x, flip = flip, keep_empty = keep_empty, group_by = group_by, group_by_sep = group_by_sep, group_name = group_name,
                 x_text_angle = x_text_angle, fill_mode = fill_mode, fill_reverse = fill_reverse,
-                theme = theme, theme_args = theme_args, palette = palette, palcolor = palcolor, alpha = alpha,
+                theme = theme, theme_args = theme_args, palette = palette[nm], palcolor = palcolor, alpha = alpha,
                 aspect.ratio = aspect.ratio, legend.position = legend.position, legend.direction = legend.direction,
                 add_point = add_point, pt_color = pt_color, pt_size = pt_size, pt_alpha = pt_alpha,
                 jitter_width = jitter_width, jitter_height = jitter_height, stack = stack, y_max = y_max, y_min = y_min,


### PR DESCRIPTION
Hi,

Thank you for developing this impressive visualization package.
I recently found this package in CRAN and am already using it heavily in my research.

One feature I would like to propose in this PR is the multiple palettes selection when `split_by` argument is specified. When I want to change the palette per plot, I think this can be convenient.

I made a simple commit that implements this functionality in `boxviolinplot.R` working like below.
May I kindly ask for your feedback?

``` r
library(plotthis)
set.seed(8525)
data <- data.frame(
    x = factor(rep(1:8, 40)),
    y = rnorm(320),
    group1 = sample(c("g1", "g2"), 320, replace = TRUE),
    group2 = sample(c("h1", "h2", "h3", "h4"), 320, replace = TRUE)
)
BoxPlot(data, x = "x", y = "y", split_by="group1", palette="Reds")
```

![](https://i.imgur.com/3TPJ29X.png)<!-- -->

``` r
BoxPlot(data, x = "x", y = "y", split_by="group1", palette=c("Reds","Blues"))
```

![](https://i.imgur.com/6X840pZ.png)<!-- -->

<sup>Created on 2024-11-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

